### PR TITLE
Avoid fatal error when an EntityIdValue cannot be mapped

### DIFF
--- a/src/EntityImporter.php
+++ b/src/EntityImporter.php
@@ -81,7 +81,7 @@ class EntityImporter {
 
 				$localId = $this->entityMappingStore->getLocalId( $entity->getId() );
 
-				if ( !$this->statementsCountLookup->hasStatements( $localId ) ) {
+				if ( $localId && !$this->statementsCountLookup->hasStatements( $localId ) ) {
 					$this->statementsImporter->importStatements( $entity );
 				} else {
 					$this->logger->info(

--- a/src/StatementCopier.php
+++ b/src/StatementCopier.php
@@ -50,7 +50,13 @@ class StatementCopier {
 	}
 
 	private function copySnak( Snak $mainSnak ) {
-		$newPropertyId = $this->entityMappingStore->getLocalId( $mainSnak->getPropertyId() );
+		$oldPropertyId = $mainSnak->getPropertyId();
+		$newPropertyId = $this->entityMappingStore->getLocalId( $oldPropertyId );
+
+		if ( !$newPropertyId ) {
+			$this->logger->error( "Entity not found for $oldPropertyId." );
+			$newPropertyId = $oldPropertyId;
+		}
 
 		switch( $mainSnak->getType() ) {
 			case 'somevalue':

--- a/src/StatementCopier.php
+++ b/src/StatementCopier.php
@@ -61,7 +61,13 @@ class StatementCopier {
 				$value = $mainSnak->getDataValue();
 
 				if ( $value instanceof EntityIdValue ) {
-					$value = $this->replaceEntityIdValue( $value );
+					$newValue = $this->replaceEntityIdValue( $value );
+
+					if ( $newValue ) {
+						// If we can't map the id, keep the old one.
+						// replaceEntityIdValue() already logged the issue.
+						$value = $newValue;
+					}
 				}
 
 				return new PropertyValueSnak( $newPropertyId, $value );
@@ -74,6 +80,7 @@ class StatementCopier {
 
 		if ( !$localId ) {
 			$this->logger->error( "Entity not found for $originalId." );
+			return null;
 		}
 
 		return new EntityIdValue( $localId );

--- a/src/StatementsImporter.php
+++ b/src/StatementsImporter.php
@@ -57,12 +57,12 @@ class StatementsImporter {
 
 				if ( !$localId ) {
 					$this->logger->error( $entityId->getSerialization() .  ' not found' );
-				}
-
-				try {
-					$this->addStatementList( $localId, $statements );
-				} catch ( \Exception $ex ) {
-					$this->logger->error( $ex->getMessage() );
+				} else {
+					try {
+						$this->addStatementList( $localId, $statements );
+					} catch ( \Exception $ex ) {
+						$this->logger->error( $ex->getMessage() );
+					}
 				}
 			} else {
 				$this->logger->error( 'EntityId not set for entity' );

--- a/src/Store/DBImportedEntityMappingStore.php
+++ b/src/Store/DBImportedEntityMappingStore.php
@@ -43,7 +43,7 @@ class DBImportedEntityMappingStore implements ImportedEntityMappingStore {
 	/**
 	 * @param EntityId $originalId
 	 *
-	 * @return EntityId
+	 * @return EntityId|null
 	 */
 	public function getLocalId( EntityId $originalId ) {
 		$dbw = $this->loadBalancer->getConnection( DB_MASTER );
@@ -67,7 +67,7 @@ class DBImportedEntityMappingStore implements ImportedEntityMappingStore {
 	/**
 	 * @param EntityId $localId
 	 *
-	 * @return EntityId
+	 * @return EntityId|null
 	 */
 	public function getOriginalId( EntityId $localId ) {
 		$dbw = $this->loadBalancer->getConnection( DB_MASTER );

--- a/src/Store/ImportedEntityMappingStore.php
+++ b/src/Store/ImportedEntityMappingStore.php
@@ -15,14 +15,14 @@ interface ImportedEntityMappingStore {
 	/**
 	 * @param EntityId $originalId
 	 *
-	 * @return EntityId
+	 * @return EntityId|null
 	 */
 	public function getLocalId( EntityId $originalId );
 
 	/**
 	 * @param EntityId $localId
 	 *
-	 * @return EntityId
+	 * @return EntityId|null
 	 */
 	public function getOriginalId( EntityId $localId );
 


### PR DESCRIPTION
When an EntityIdValue cannot be mapped, let's just keep the unmapped value, instead of triggering a fatal error.
