### PR TITLE
clarify which maintainance folder the script is in

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To add the table, run MediaWiki's ```update.php``` maintenance script.
 
 Usage
 ------
+First, navigate to *WikibaseImport* ’s extension folder.
 
 Import a specific entity:
 


### PR DESCRIPTION
Hi @filbertkm
I just used your extension to import some items in my local installation (Thanks!).

I assumed initially that the maintenance folder in the usage section referred to the Mediawiki’s maintenance folder, though actually the extension’s folder was meant. Thus, I added a line clarifying this.
