### PR TITLE
Add option to read entity IDs from standard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Import a range of entities:
 ```
 php maintenance/importEntities.php --range Q1:Q20
 ```
+
+Import a list of entities printed by another program:
+
+```
+printf 'Q%s\n' {1..20} {100..120} | php maintenance/importEntities.php --stdin
+```

--- a/maintenance/importEntities.php
+++ b/maintenance/importEntities.php
@@ -39,6 +39,7 @@ class ImportEntities extends \Maintenance {
 		$this->addOption( 'entity', 'ID of entity to import', false, true );
 		$this->addOption( 'query', 'Import items with property and entity id value', false, true );
 		$this->addOption( 'range', 'Range of ids to import', false, true );
+		$this->addOption( 'stdin', 'Read entity IDs to import from standard input', false, false );
 		$this->addOption( 'all-properties', 'Import all properties', false, false );
 	}
 
@@ -98,7 +99,7 @@ class ImportEntities extends \Maintenance {
 	}
 
 	private function getValidOptions() {
-		return [ 'entity', 'file', 'all-properties', 'query', 'range' ];
+		return [ 'entity', 'file', 'all-properties', 'query', 'range', 'stdin' ];
 	}
 
 	private function newEntityIdListBuilderFactory() {

--- a/src/EntityId/EntityIdListBuilderFactory.php
+++ b/src/EntityId/EntityIdListBuilderFactory.php
@@ -65,6 +65,8 @@ class EntityIdListBuilderFactory {
 				return $this->newRangeEntityIdListBuilder();
 			case 'query':
 				return $this->newQueryEntityIdListBuilder();
+			case 'stdin':
+				return $this->newStdinEntityIdListBuilder();
 			default:
 				throw new InvalidArgumentException( 'Unknown import mode: ' . $mode );
 		}
@@ -94,6 +96,10 @@ class EntityIdListBuilderFactory {
 
 	private function newRangeEntityIdListBuilder() {
 		return new RangeEntityIdListBuilder( $this->idParser );
+	}
+
+	private function newStdinEntityIdListBuilder() {
+		return new StdinEntityIdListBuilder();
 	}
 
 }

--- a/src/EntityId/StdinEntityIdListBuilder.php
+++ b/src/EntityId/StdinEntityIdListBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Wikibase\Import\EntityId;
+
+use RuntimeException;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Lucas Werkmeister < lucas.werkmeister@wikimedia.de >
+ */
+class StdinEntityIdListBuilder implements EntityIdListBuilder {
+
+	/**
+	 * @param string $input (ignored)
+	 *
+	 * @throws RuntimeException
+	 * @return string[]
+	 */
+	public function getEntityIds( $input ) {
+		$entityIds = [];
+		while ( $line = fgets( STDIN ) ) {
+			$entityIds[] = trim( $line );
+		}
+		return $entityIds;
+	}
+
+}


### PR DESCRIPTION
Specifying `/dev/stdin` as filename does not work on Linux if standard input is a pipe, since PHP does not [**open**(2)][open(2)] the symlink directly, but instead follows it using [**readlink**(2)][readlink(2)], and the Linux kernel returns a non-filename description for [**readlink**(2)][readlink(2)] on `/proc/[pid]/fd/` entries corresponding to pipes and sockets (see [**proc**(5)][proc(5)]):

```c
readlink("/dev/stdin") -> /proc/self/fd/0
readlink("/proc/self/fd/0") -> pipe:[INODE]
/* ... resolve /proc/self ... */
open("/proc/PID/fd/pipe:[INODE]") -> ENOENT
```

[open(2)]: http://man7.org/linux/man-pages/man2/open.2.html
[readlink(2)]: http://man7.org/linux/man-pages/man2/readlink.2.html
[proc(5)]: http://man7.org/linux/man-pages/man5/proc.5.html