### PR TITLE
Update for WikibaseRepo method rename

### DIFF
--- a/src/EntityImporterFactory.php
+++ b/src/EntityImporterFactory.php
@@ -117,7 +117,7 @@ class EntityImporterFactory {
 	private function newEntityDeserializer() {
 		$wikibaseRepo = WikibaseRepo::getDefaultInstance();
 
-		$deserializerFactory = $wikibaseRepo->getExternalFormatDeserializerFactory();
+		$deserializerFactory = $wikibaseRepo->getBaseDataModelDeserializerFactory();
 
 		return $deserializerFactory->newEntityDeserializer();
 	}


### PR DESCRIPTION
In commit fca4960 (change I23621ed), the method was renamed from `getExternalFormatDeserializerFactory` to `getBaseDataModelDeserializerFactory`.