### PR TITLE
Initialize user from session

### DIFF
--- a/src/EntityImporter.php
+++ b/src/EntityImporter.php
@@ -53,7 +53,7 @@ class EntityImporter {
 		$this->logger = $logger;
 
 		$this->idParser = new BasicEntityIdParser();
-		$this->importUser = User::newFromId( 0 );
+		$this->importUser = User::newFromSession();
 		$this->batchSize = 10;
 	}
 


### PR DESCRIPTION
If the import script is run from the command line, there is no session, and the edit is still credited to 127.0.0.1. However, if there is a session – for example, if the import is run from a special page (#25) – this ensures that the correct user is used.