### PR TITLE
Declare generic EntityStore as parameter type

### DIFF
--- a/src/EntityImporter.php
+++ b/src/EntityImporter.php
@@ -11,7 +11,7 @@ use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\Import\Store\ImportedEntityMappingStore;
-use Wikibase\Repo\Store\WikiPageEntityStore;
+use Wikibase\Lib\Store\EntityStore;
 
 class EntityImporter {
 
@@ -39,7 +39,7 @@ class EntityImporter {
 		StatementsImporter $statementsImporter,
 		BadgeItemUpdater $badgeItemUpdater,
 		ApiEntityLookup $apiEntityLookup,
-		WikiPageEntityStore $entityStore,
+		EntityStore $entityStore,
 		ImportedEntityMappingStore $entityMappingStore,
 		StatementsCountLookup $statementsCountLookup,
 		LoggerInterface $logger


### PR DESCRIPTION
`Store::getEntityStore()` (which is where `ImportEntities::newEntityImporter()` gets the entity store from) has never promised to return more than a generic `EntityStore`, and with wikimedia/mediawiki-extensions-Wikibase@91a07a3901 (change [I84661212a6](https://gerrit.wikimedia.org/r/394070/)), it has started to return a `TypeDispatchingEntityStore` instead of a `WikiPageEntityStore`. As far as I can tell, we don’t need anything specific to `WikiPageEntityStore`, so adjusting the parameter type should be enough to fix this problem.