### PR TITLE
Extension loading improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then go into the WikibaseImport extension directory and run ```composer update``
 Then, to enable the extension, add it in your ```LocalSettings.php``` file:
 
 ```
-require_once "$IP/extensions/WikibaseImport/WikibaseImport.php";
+wfLoadExtension( 'WikibaseImport' );
 ```
 
 The extension requires a new database table to map entity ids from the foreign

--- a/WikibaseImport.php
+++ b/WikibaseImport.php
@@ -1,10 +1,6 @@
 <?php
 
 if ( function_exists( 'wfLoadExtension' ) ) {
-	if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-		require_once __DIR__ . '/vendor/autoload.php';
-	}
-
 	wfLoadExtension( 'WikibaseImport', __DIR__ . '/extension.json' );
 } else {
 	die( 'WikibaseImport requires MediaWiki 1.25+' );

--- a/WikibaseImport.php
+++ b/WikibaseImport.php
@@ -2,6 +2,11 @@
 
 if ( function_exists( 'wfLoadExtension' ) ) {
 	wfLoadExtension( 'WikibaseImport', __DIR__ . '/extension.json' );
+	wfWarn(
+		'Deprecated PHP entry point used for WikibaseImport extension. ' .
+		'Please use wfLoadExtension instead, ' .
+		'see https://www.mediawiki.org/wiki/Extension_registration for more details.'
+	);
 } else {
 	die( 'WikibaseImport requires MediaWiki 1.25+' );
 }

--- a/WikibaseImport.php
+++ b/WikibaseImport.php
@@ -2,6 +2,9 @@
 
 if ( function_exists( 'wfLoadExtension' ) ) {
 	wfLoadExtension( 'WikibaseImport', __DIR__ . '/extension.json' );
+	// Keep i18n globals so mergeMessageFileList.php doesn't break
+	$wgMessagesDirs['WikibaseImport'] = __DIR__ . '/i18n';
+	$wgExtensionMessagesFiles['WikibaseImportAlias'] = __DIR__ . '/WikibaseImport.i18n.alias.php';
 	wfWarn(
 		'Deprecated PHP entry point used for WikibaseImport extension. ' .
 		'Please use wfLoadExtension instead, ' .

--- a/extension.json
+++ b/extension.json
@@ -1,4 +1,5 @@
 {
+	"load_composer_autoloader": true,
 	"name": "Wikibase Import",
 	"version": "0.1",
 	"author": [


### PR DESCRIPTION
The PHP entry point is now almost identical to the [mediawiki.org example](https://www.mediawiki.org/wiki/Manual:Extension_registration#Migration_for_extension_developers). See commit messages for details.

Feel free to only merge a subset of these commits if you like :)

Fixes #32.