### PR TITLE
Make wikibase/datamodel 9.0 acceptable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php": ">=5.5.0",
 		"benestar/asparagus": "~0.4",
 		"monolog/monolog": "~1.18",
-		"wikibase/data-model": "~6.0|~7.0"
+		"wikibase/data-model": "~6.0|~7.0|~9.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
We're now using 9.x in Wikibase so it would be nice to bump this here.

My quick test says this still works.