### PR TITLE
Search entities in the correct namespace

### DIFF
--- a/src/EntityImporterFactory.php
+++ b/src/EntityImporterFactory.php
@@ -70,7 +70,7 @@ class EntityImporterFactory {
 				$this->getApiEntityLookup(),
 				$this->entityStore,
 				$this->getImportedEntityMappingStore(),
-				new PagePropsStatementCountLookup( $this->loadBalancer ),
+				new PagePropsStatementCountLookup( $this->loadBalancer, $this->getEntityNamespaceLookup() ),
 				$this->logger
 			);
 		}
@@ -126,6 +126,12 @@ class EntityImporterFactory {
 		return new SerializerFactory(
 			new DataValueSerializer()
 		);
+	}
+
+	private function getEntityNamespaceLookup() {
+		$wikibaseRepo = WikibaseRepo::getDefaultInstance();
+
+		return $wikibaseRepo->getEntityNamespaceLookup();
 	}
 }
 


### PR DESCRIPTION
Instead of assuming that all entities are in namespace 0 (which is only true in a Wikidata-like installation, but not in a default Wikibase installation, and even then only for items, not properties), take the actual namespace of the requested entity from an injected `EntityNamespaceLookup`.

Also, if we can’t find the entity, throw an exception instead of returning count 0: it’s better to fail the import than to duplicate statements.

Fixes #22.